### PR TITLE
Update usePx scale formula

### DIFF
--- a/src/use-px/init.luau
+++ b/src/use-px/init.luau
@@ -39,7 +39,7 @@ local function usePx(
     local width = math.log(viewport.X / use(baseResolution).X, 2)
     local height = math.log(viewport.Y / use(baseResolution).Y, 2)
     local centered = width + (height - width) * use(dominantAxis)
-    return math.max(2 * centered, use(minimumScale))
+    return math.max(2 ^ centered, use(minimumScale))
   end)
 
   local px = {} :: any


### PR DESCRIPTION
The formula for scale is incorrect, and results in the px value nearly always staying static at the MIN_SCALE value. Formula changed to align with the one in https://gist.github.com/grilme99/c67a14caa7417b09276f50abbf03a9a4